### PR TITLE
Router name filtered for striping whitespaces

### DIFF
--- a/UrlGenerator.php
+++ b/UrlGenerator.php
@@ -381,7 +381,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function route($name, $parameters = [], $absolute = true)
     {
-        if (! is_null($route = $this->routes->getByName($name))) {
+        if (! is_null($route = $this->routes->getByName(trim($name)))) {
             return $this->toRoute($route, $parameters, $absolute);
         }
 
@@ -398,7 +398,7 @@ class UrlGenerator implements UrlGeneratorContract
      *
      * @throws \Illuminate\Routing\Exceptions\UrlGenerationException
      */
-    public function toRoute($route, $parameters, $absolute)
+    protected function toRoute($route, $parameters, $absolute)
     {
         return $this->routeUrl()->to(
             $route, $this->formatParameters($parameters), $absolute


### PR DESCRIPTION
While coding I faced with incorrect router name error. I have realized that there is whitespace on begining of my router name because of it I have filtered router name ignoring whitespaces. It irritates me a lot finding conflict if there is whitespace on the begin or end of my router name.I would like my PR to be accepted. 