### PR TITLE
run php artisan route:cache,route bindings  wrong

### DIFF
--- a/RouteGroup.php
+++ b/RouteGroup.php
@@ -59,7 +59,7 @@ class RouteGroup
     {
         $old = $old['prefix'] ?? null;
 
-        return isset($new['prefix']) ? trim($old, '/').'/'.trim($new['prefix'], '/') : $old;
+        return isset($new['prefix']) ? trim($new['prefix'], '/').'/'.trim($old, '/') : $old;
     }
 
     /**


### PR DESCRIPTION
When I use the route cache, the prefix route binding parameters will report an error, so I trace the source code and modify it here is no problem
![image](https://user-images.githubusercontent.com/20275621/77682155-6dd8e380-6fd1-11ea-9b93-805d5cd8502e.png)

![image](https://user-images.githubusercontent.com/20275621/77681739-c8257480-6fd0-11ea-9af1-aedc96b88036.png)
