### PR TITLE
Trim function on nulled variable

### DIFF
--- a/RouteGroup.php
+++ b/RouteGroup.php
@@ -62,7 +62,7 @@ class RouteGroup
         $old = $old['prefix'] ?? null;
 
         if ($prependExistingPrefix) {
-            return isset($new['prefix']) ? trim($old, '/').'/'.trim($new['prefix'], '/') : $old;
+            return isset($new['prefix']) ? ($old ? trim($old, '/') : null ).'/'.trim($new['prefix'], '/') : $old;
         } else {
             return isset($new['prefix']) ? trim($new['prefix'], '/').'/'.trim($old, '/') : $old;
         }


### PR DESCRIPTION
Trim nulled value is depreciated on php 7.4 >=
Fixing to avoid warnings and fatal errors like:
```console
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi

   ErrorException 

  trim(): Passing null to parameter #1 ($string) of type string is deprecated